### PR TITLE
 Fixed failure to match running containers when directory has dashes

### DIFF
--- a/project/find_first_running_container.go
+++ b/project/find_first_running_container.go
@@ -1,12 +1,23 @@
 package project
 
 import (
+	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 )
 
+// FindFirstRunningContainer finds the state of the first running container
+// matching the given service name.
 func FindFirstRunningContainer(serviceName string, containers []ContainerState) ContainerState {
 	var foundContainer ContainerState
-	rp := regexp.MustCompile("^\\w+_" + serviceName + "_\\d+")
+	currentWorkdir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dirName := filepath.Base(currentWorkdir)
+	rp := regexp.MustCompile("^" + dirName + "_" + serviceName + "_\\d+")
 
 	for i := range containers {
 		if rp.FindString(containers[i].Name) != "" {


### PR DESCRIPTION
### What does this PR do?

* Updates the `project.FindFirstRunningContainer` function, so it uses the current directory's base path into account when looking for running containers

Closes #15 
