### PR TITLE
Fixing regex for dirnames capitalized

### DIFF
--- a/project/find_first_running_container.go
+++ b/project/find_first_running_container.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 // FindFirstRunningContainer finds the state of the first running container
@@ -16,7 +17,7 @@ func FindFirstRunningContainer(serviceName string, containers []ContainerState) 
 		log.Fatal(err)
 	}
 
-	dirName := filepath.Base(currentWorkdir)
+	dirName := strings.ToLower(filepath.Base(currentWorkdir))
 	rp := regexp.MustCompile("^" + dirName + "_" + serviceName + "_\\d+")
 
 	for i := range containers {

--- a/project/find_first_running_container.go
+++ b/project/find_first_running_container.go
@@ -17,8 +17,11 @@ func FindFirstRunningContainer(serviceName string, containers []ContainerState) 
 		log.Fatal(err)
 	}
 
-	dirName := strings.ToLower(filepath.Base(currentWorkdir))
-	rp := regexp.MustCompile("^" + dirName + "_" + serviceName + "_\\d+")
+	dirName := filepath.Base(currentWorkdir)
+
+	containerName := strings.ToLower(dirName + "_" + serviceName)
+
+	rp := regexp.MustCompile("^" + containerName + "_\\d+")
 
 	for i := range containers {
 		if rp.FindString(containers[i].Name) != "" {


### PR DESCRIPTION
### What does this PR do?

* Fix regex on directory names capitalized

Like referenced on issue #19, the latest release of `plis` can't attach containers on directories which its name are capitalized, for example: 

- `BACK-END-3`,  docker-compose uses `back-end-3` as namespace but the current regex looks for `BACK-END-3`
